### PR TITLE
feat: uips-log-parser skill, project scaffold, and CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "agentskills",
+  "metadata": {
+    "description": "Agent skills for UiPath Studio (uips) development workflows",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "uips-skills",
+      "description": "Skills for UiPath Studio development: log parsing, diagramming, and automation workflows.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/uips-log-parser"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/strip-docs-from-main.yml
+++ b/.github/workflows/strip-docs-from-main.yml
@@ -1,0 +1,23 @@
+name: Strip docs/ from main
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+
+jobs:
+  strip-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove docs/ and commit if present
+        run: |
+          git rm -r --ignore-unmatch docs/
+          git diff --cached --quiet && echo "docs/ not present, nothing to do." && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: remove docs/ from main [skip ci]"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/

--- a/docs/vendor/agentskills.io/web/client-implementation/adding-skills-support.md
+++ b/docs/vendor/agentskills.io/web/client-implementation/adding-skills-support.md
@@ -1,0 +1,103 @@
+# How to add skills support to your agent
+
+> A guide for adding Agent Skills support to an AI agent or development tool.
+
+## The core principle: progressive disclosure
+
+Every skills-compatible agent follows the same three-tier loading strategy:
+
+| Tier | What's loaded | When | Token cost |
+|------|---------------|------|------------|
+| 1. Catalog | Name + description | Session start | ~50-100 tokens per skill |
+| 2. Instructions | Full `SKILL.md` body | When the skill is activated | <5000 tokens (recommended) |
+| 3. Resources | Scripts, references, assets | When the instructions reference them | Varies |
+
+## Step 1: Discover skills
+
+Scan these directories at session startup:
+
+| Scope | Path | Purpose |
+|-------|------|---------|
+| Project | `<project>/.<your-client>/skills/` | Your client's native location |
+| Project | `<project>/.agents/skills/` | Cross-client interoperability |
+| User | `~/.<your-client>/skills/` | Your client's native location |
+| User | `~/.agents/skills/` | Cross-client interoperability |
+
+Within each skills directory, look for subdirectories containing a file named exactly `SKILL.md`.
+
+**Scanning rules:**
+- Skip `.git/`, `node_modules/`
+- Set reasonable bounds (max depth 4-6, max 2000 directories)
+- Project-level skills override user-level skills on name collision
+- Warn when a collision shadows a skill
+
+**Trust:** Consider gating project-level skill loading on a trust check — untrusted repos should not silently inject instructions.
+
+## Step 2: Parse `SKILL.md` files
+
+1. Find the opening `---` and closing `---` delimiter
+2. Parse the YAML block — extract `name` and `description` (required)
+3. Everything after closing `---` is the body
+
+**Store per skill:** `name`, `description`, `location` (absolute path to `SKILL.md`)
+
+**Lenient validation:**
+- Name doesn't match directory → warn, load anyway
+- Name exceeds 64 chars → warn, load anyway
+- Description missing → skip the skill
+- YAML unparseable → skip the skill
+
+## Step 3: Disclose available skills to the model
+
+Build a catalog of name + description (+ optionally location) for all discovered skills:
+
+```xml
+<available_skills>
+  <skill>
+    <name>pdf-processing</name>
+    <description>Extract PDF text, fill forms, merge files. Use when handling PDFs.</description>
+    <location>/home/user/.agents/skills/pdf-processing/SKILL.md</location>
+  </skill>
+</available_skills>
+```
+
+Include behavioral instructions alongside the catalog:
+
+- **File-read activation:** "When a task matches a skill's description, use your file-read tool to load the SKILL.md at the listed location before proceeding."
+- **Dedicated tool activation:** "When a task matches a skill's description, call the `activate_skill` tool with the skill's name."
+
+**If no skills are available:** omit the catalog and instructions entirely.
+
+## Step 4: Activate skills
+
+**Model-driven activation (file-read):** Model calls its file-read tool with the `SKILL.md` path. Simplest approach when the model has file access.
+
+**Model-driven activation (dedicated tool):** Register `activate_skill(name)` that returns skill content. Advantages: control content format, wrap in structured tags, enumerate resources, enforce permissions.
+
+**User-explicit activation:** Slash command or mention syntax (`/skill-name`) intercepted by the harness.
+
+**Structured wrapping (recommended for dedicated tools):**
+```xml
+<skill_content name="pdf-processing">
+# PDF Processing
+[body content]
+
+Skill directory: /home/user/.agents/skills/pdf-processing
+<skill_resources>
+  <file>scripts/extract.py</file>
+  <file>references/pdf-spec-summary.md</file>
+</skill_resources>
+</skill_content>
+```
+
+**Permission allowlisting:** Allowlist skill directories so the model can read bundled resources without per-file confirmation prompts.
+
+## Step 5: Manage skill context over time
+
+- **Protect from context compaction:** Exempt skill content from pruning/summarisation — losing it mid-conversation silently degrades performance.
+- **Deduplicate activations:** Track which skills are already in context; skip re-injection.
+- **Subagent delegation (advanced):** Run the skill in a separate subagent session for complex workflows.
+
+---
+
+*Source: https://agentskills.io/client-implementation/adding-skills-support.md — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/index.md
+++ b/docs/vendor/agentskills.io/web/index.md
@@ -1,0 +1,80 @@
+# Overview
+
+> A simple, open format for giving agents new capabilities and expertise.
+
+Agent Skills are folders of instructions, scripts, and resources that agents can discover and use to do things more accurately and efficiently.
+
+## Why Agent Skills?
+
+Agents are increasingly capable, but often don't have the context they need to do real work reliably. Skills solve this by giving agents access to procedural knowledge and company-, team-, and user-specific context they can load on demand. Agents with access to a set of skills can extend their capabilities based on the task they're working on.
+
+**For skill authors**: Build capabilities once and deploy them across multiple agent products.
+
+**For compatible agents**: Support for skills lets end users give agents new capabilities out of the box.
+
+**For teams and enterprises**: Capture organizational knowledge in portable, version-controlled packages.
+
+## What can Agent Skills enable?
+
+- **Domain expertise**: Package specialized knowledge into reusable instructions, from legal review processes to data analysis pipelines.
+- **New capabilities**: Give agents new capabilities (e.g. creating presentations, building MCP servers, analyzing datasets).
+- **Repeatable workflows**: Turn multi-step tasks into consistent and auditable workflows.
+- **Interoperability**: Reuse the same skill across different skills-compatible agent products.
+
+## Adoption
+
+Agent Skills are supported by leading AI development tools, including:
+
+| Agent / Tool | Instructions URL | Source |
+|---|---|---|
+| Junie (JetBrains) | https://junie.jetbrains.com/docs/agent-skills.html | — |
+| Gemini CLI | https://geminicli.com/docs/cli/skills/ | https://github.com/google-gemini/gemini-cli |
+| Autohand Code CLI | https://autohand.ai/docs/working-with-autohand-code/agent-skills.html | https://github.com/autohandai/code-cli |
+| OpenCode | https://opencode.ai/docs/skills/ | https://github.com/sst/opencode |
+| OpenHands | https://docs.openhands.dev/overview/skills | https://github.com/OpenHands/OpenHands |
+| Mux | https://mux.coder.com/agent-skills | https://github.com/coder/mux |
+| Cursor | https://cursor.com/docs/context/skills | — |
+| Amp | https://ampcode.com/manual#agent-skills | — |
+| Letta | https://docs.letta.com/letta-code/skills/ | https://github.com/letta-ai/letta |
+| Firebender | https://docs.firebender.com/multi-agent/skills | — |
+| Goose | https://block.github.io/goose/docs/guides/context-engineering/using-skills/ | https://github.com/block/goose |
+| GitHub Copilot | https://docs.github.com/en/copilot/concepts/agents/about-agent-skills | https://github.com/microsoft/vscode-copilot-chat |
+| VS Code | https://code.visualstudio.com/docs/copilot/customization/agent-skills | https://github.com/microsoft/vscode |
+| Claude Code | https://code.claude.com/docs/en/skills | — |
+| Claude | https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview | — |
+| OpenAI Codex | https://developers.openai.com/codex/skills/ | https://github.com/openai/codex |
+| Factory | https://docs.factory.ai/cli/configuration/skills.md | — |
+| pi | https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md | https://github.com/badlogic/pi-mono |
+| Databricks | https://docs.databricks.com/aws/en/assistant/skills | — |
+| Agentman | https://agentman.ai/agentskills | — |
+| TRAE | https://www.trae.ai/blog/trae_tutorial_0115 | https://github.com/bytedance/trae-agent |
+| Spring AI | https://spring.io/blog/2026/01/13/spring-ai-generic-agent-skills/ | https://github.com/spring-projects/spring-ai |
+| Roo Code | https://docs.roocode.com/features/skills | https://github.com/RooCodeInc/Roo-Code |
+| Mistral AI Vibe | https://github.com/mistralai/mistral-vibe | https://github.com/mistralai/mistral-vibe |
+| Command Code | https://commandcode.ai/docs/skills | — |
+| Ona | https://ona.com/docs/ona/agents-md#skills-for-repository-specific-workflows | — |
+| VT Code | https://github.com/vinhnx/vtcode/blob/main/docs/skills/SKILLS_GUIDE.md | https://github.com/vinhnx/VTCode |
+| Qodo | https://www.qodo.ai/blog/how-i-use-qodos-agent-skills-to-auto-fix-issues-in-pull-requests/ | — |
+| Laravel Boost | https://laravel.com/docs/12.x/boost#agent-skills | https://github.com/laravel/boost |
+| Emdash | https://docs.emdash.sh/skills | https://github.com/generalaction/emdash |
+| Snowflake Cortex | https://docs.snowflake.com/en/user-guide/cortex-code/extensibility#extensibility-skills | — |
+| Kiro | https://kiro.dev/docs/skills/ | — |
+
+## Open Development
+
+The Agent Skills format was originally developed by [Anthropic](https://www.anthropic.com/), released as an open standard, and has been adopted by a growing number of agent products. The standard is open to contributions from the broader ecosystem.
+
+- GitHub: https://github.com/agentskills/agentskills
+- Discord: https://discord.gg/MKPE9g8aUy
+
+## Get Started
+
+- [What are skills?](https://agentskills.io/what-are-skills) — Learn about skills, how they work, and why they matter.
+- [Specification](https://agentskills.io/specification) — The complete format specification for SKILL.md files.
+- [Add skills support](https://agentskills.io/client-implementation/adding-skills-support) — Add skills support to your agent or tool.
+- [Example skills](https://github.com/anthropics/skills) — Browse example skills on GitHub.
+- [Reference library](https://github.com/agentskills/agentskills/tree/main/skills-ref) — Validate skills and generate prompt XML.
+
+---
+
+*Source: https://agentskills.io/ — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/llms.txt
+++ b/docs/vendor/agentskills.io/web/llms.txt
@@ -1,0 +1,20 @@
+# Agent Skills
+
+## Docs
+
+- [How to add skills support to your agent](https://agentskills.io/client-implementation/adding-skills-support.md): A guide for adding Agent Skills support to an AI agent or development tool.
+- [Overview](https://agentskills.io/home.md): A simple, open format for giving agents new capabilities and expertise.
+- [Best practices for skill creators](https://agentskills.io/skill-creation/best-practices.md): How to write skills that are well-scoped and calibrated to the task.
+- [Evaluating skill output quality](https://agentskills.io/skill-creation/evaluating-skills.md): How to test whether your skill produces good outputs using eval-driven iteration.
+- [Optimizing skill descriptions](https://agentskills.io/skill-creation/optimizing-descriptions.md): How to improve your skill's description so it triggers reliably on relevant prompts.
+- [Quickstart](https://agentskills.io/skill-creation/quickstart.md): Create your first Agent Skill and see it work in VS Code.
+- [Using scripts in skills](https://agentskills.io/skill-creation/using-scripts.md): How to run commands and bundle executable scripts in your skills.
+- [Specification](https://agentskills.io/specification.md): The complete format specification for Agent Skills.
+- [What are skills?](https://agentskills.io/what-are-skills.md): Agent Skills are a lightweight, open format for extending AI agent capabilities with specialized knowledge and workflows.
+
+
+Built with [Mintlify](https://mintlify.com).
+
+---
+
+*Source: https://agentskills.io/llms.txt — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/skill-creation/best-practices.md
+++ b/docs/vendor/agentskills.io/web/skill-creation/best-practices.md
@@ -1,0 +1,161 @@
+# Best practices for skill creators
+
+> How to write skills that are well-scoped and calibrated to the task.
+
+## Start from real expertise
+
+Effective skills are grounded in real expertise, not generic LLM output. Feed domain-specific context into the creation process.
+
+**Extract from a hands-on task:** Complete a real task with an agent, then extract the reusable pattern. Note:
+- Steps that worked
+- Corrections you made (e.g., "use library X instead of Y")
+- Input/output formats
+- Context you provided (project-specific facts, conventions)
+
+**Synthesize from project artifacts:** Good source material:
+- Internal documentation, runbooks, style guides
+- API specs, schemas, configuration files
+- Code review comments and issue trackers
+- Version control history, especially patches and fixes
+- Real-world failure cases and resolutions
+
+## Refine with real execution
+
+Run the skill against real tasks, then feed all results back into the creation process. Even one pass of execute-then-revise noticeably improves quality.
+
+Read agent execution traces, not just final outputs — wasted steps reveal vague instructions, misapplied instructions, or too many options without a clear default.
+
+## Spending context wisely
+
+### Add what the agent lacks, omit what it knows
+
+Focus on project-specific conventions, domain-specific procedures, non-obvious edge cases. Skip explanations of general concepts the agent already knows.
+
+```markdown
+<!-- Too verbose -->
+PDF (Portable Document Format) files are a common file format...
+Use pdfplumber because it handles most cases well.
+
+<!-- Better -->
+Use pdfplumber for text extraction. For scanned documents, fall back to
+pdf2image with pytesseract.
+```
+
+### Design coherent units
+
+Scope a skill to a coherent unit of work — too narrow forces multiple skills per task; too broad makes precise activation hard.
+
+### Keep SKILL.md under 500 lines
+
+Move detailed reference material to `references/`. Tell the agent *when* to load each file:
+
+> "Read `references/api-errors.md` if the API returns a non-200 status code"
+
+## Calibrating control
+
+### Match specificity to fragility
+
+**Give freedom** when multiple approaches are valid — explain *why* rather than rigid directives.
+
+**Be prescriptive** when operations are fragile or a specific sequence must be followed:
+
+```markdown
+## Database migration
+
+Run exactly this sequence:
+
+```bash
+python scripts/migrate.py --verify --backup
+```
+
+Do not modify the command or add additional flags.
+```
+
+### Provide defaults, not menus
+
+Pick a default and mention alternatives briefly:
+
+```markdown
+<!-- Too many options -->
+You can use pypdf, pdfplumber, PyMuPDF, or pdf2image...
+
+<!-- Clear default with escape hatch -->
+Use pdfplumber for text extraction.
+For scanned PDFs requiring OCR, use pdf2image with pytesseract instead.
+```
+
+### Favor procedures over declarations
+
+Teach the agent *how to approach* a class of problems, not what to produce for one specific instance.
+
+## Patterns for effective instructions
+
+### Gotchas sections
+
+Highest-value content — concrete corrections to mistakes the agent will make without being told:
+
+```markdown
+## Gotchas
+
+- The `users` table uses soft deletes. Queries must include
+  `WHERE deleted_at IS NULL`.
+- The user ID is `user_id` in the database, `uid` in the auth service,
+  and `accountId` in the billing API. All three refer to the same value.
+```
+
+When an agent makes a mistake you correct, add it to gotchas.
+
+### Templates for output format
+
+Provide a concrete template rather than describing the format in prose:
+
+```markdown
+## Report structure
+
+```markdown
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview]
+
+## Key findings
+- Finding 1 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+```
+```
+
+### Checklists for multi-step workflows
+
+```markdown
+## Form processing workflow
+
+- [ ] Step 1: Analyze the form (`scripts/analyze_form.py`)
+- [ ] Step 2: Create field mapping (`fields.json`)
+- [ ] Step 3: Validate mapping (`scripts/validate_fields.py`)
+- [ ] Step 4: Fill the form (`scripts/fill_form.py`)
+- [ ] Step 5: Verify output (`scripts/verify_output.py`)
+```
+
+### Validation loops
+
+```markdown
+1. Make your edits
+2. Run validation: `python scripts/validate.py output/`
+3. If validation fails, fix issues and run again
+4. Only proceed when validation passes
+```
+
+### Plan-validate-execute
+
+For batch or destructive operations: create an intermediate plan, validate against a source of truth, then execute.
+
+## Next steps
+
+- [Evaluating skill output quality](evaluating-skills.md)
+- [Optimizing skill descriptions](optimizing-descriptions.md)
+
+---
+
+*Source: https://agentskills.io/skill-creation/best-practices.md — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/skill-creation/evaluating-skills.md
+++ b/docs/vendor/agentskills.io/web/skill-creation/evaluating-skills.md
@@ -1,0 +1,138 @@
+# Evaluating skill output quality
+
+> How to test whether your skill produces good outputs using eval-driven iteration.
+
+## Designing test cases
+
+A test case has three parts:
+- **Prompt**: a realistic user message
+- **Expected output**: a human-readable description of success
+- **Input files** (optional)
+
+Store in `evals/evals.json`:
+
+```json
+{
+  "skill_name": "csv-analyzer",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have a CSV of monthly sales data in data/sales_2025.csv. Can you find the top 3 months by revenue and make a bar chart?",
+      "expected_output": "A bar chart image showing the top 3 months by revenue, with labeled axes and values.",
+      "files": ["evals/files/sales_2025.csv"]
+    }
+  ]
+}
+```
+
+**Tips:**
+- Start with 2-3 test cases
+- Vary phrasing (formal, casual, with typos)
+- Vary explicitness (some name the domain, some describe the need without naming it)
+- Cover edge cases (malformed input, unusual requests)
+
+## Workspace structure
+
+```
+csv-analyzer-workspace/
+└── iteration-1/
+    ├── eval-top-months-chart/
+    │   ├── with_skill/
+    │   │   ├── outputs/
+    │   │   ├── timing.json
+    │   │   └── grading.json
+    │   └── without_skill/
+    │       ├── outputs/
+    │       ├── timing.json
+    │       └── grading.json
+    └── benchmark.json
+```
+
+Run each test case both **with the skill** and **without** (baseline). Each run should start with a clean context.
+
+## Writing assertions
+
+Add after seeing first results. Good assertions:
+- `"The output file is valid JSON"` — programmatically verifiable
+- `"The bar chart has labeled axes"` — specific and observable
+- `"The report includes at least 3 recommendations"` — countable
+
+Weak: `"The output is good"`, `"Uses exactly the phrase X"` (too brittle)
+
+```json
+"assertions": [
+  "The output includes a bar chart image file",
+  "The chart shows exactly 3 months",
+  "Both axes are labeled",
+  "The chart title or caption mentions revenue"
+]
+```
+
+## Grading outputs
+
+Record **PASS** or **FAIL** with specific evidence quoting the output:
+
+```json
+{
+  "assertion_results": [
+    {
+      "text": "Both axes are labeled",
+      "passed": false,
+      "evidence": "Y-axis is labeled 'Revenue ($)' but X-axis has no label"
+    }
+  ],
+  "summary": { "passed": 3, "failed": 1, "total": 4, "pass_rate": 0.75 }
+}
+```
+
+**Grading principles:**
+- Require concrete evidence for a PASS — don't give benefit of the doubt
+- Review the assertions themselves for quality (too easy, too hard, unverifiable)
+
+## Aggregating results
+
+```json
+{
+  "run_summary": {
+    "with_skill": { "pass_rate": { "mean": 0.83 }, "tokens": { "mean": 3800 } },
+    "without_skill": { "pass_rate": { "mean": 0.33 }, "tokens": { "mean": 2100 } },
+    "delta": { "pass_rate": 0.50, "tokens": 1700 }
+  }
+}
+```
+
+## Analyzing patterns
+
+- Remove assertions that always pass in both configurations (no signal)
+- Investigate assertions that always fail in both (broken assertion or too hard)
+- Study assertions that pass with skill but fail without (where skill adds value)
+- Tighten instructions when results are inconsistent across runs
+
+## Iterating on the skill
+
+After grading and human review, three signal sources:
+1. **Failed assertions** → specific gaps in instructions
+2. **Human feedback** → broader quality issues
+3. **Execution transcripts** → *why* things went wrong
+
+Give all three + current `SKILL.md` to an LLM and ask it to propose changes.
+
+**Iteration guidelines:**
+- Generalize from feedback (don't add narrow patches)
+- Keep the skill lean (fewer, better instructions)
+- Explain the why (reasoning-based > rigid directives)
+- Bundle repeated work into `scripts/`
+
+### The loop
+
+1. Propose improvements from eval signals
+2. Apply changes
+3. Rerun in new `iteration-<N+1>/` directory
+4. Grade and aggregate
+5. Human review → repeat
+
+Stop when satisfied, feedback is consistently empty, or improvement stalls.
+
+---
+
+*Source: https://agentskills.io/skill-creation/evaluating-skills.md — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/skill-creation/optimizing-descriptions.md
+++ b/docs/vendor/agentskills.io/web/skill-creation/optimizing-descriptions.md
@@ -1,0 +1,92 @@
+# Optimizing skill descriptions
+
+> How to improve your skill's description so it triggers reliably on relevant prompts.
+
+A skill only helps if it gets activated. The `description` field is the primary mechanism agents use to decide whether to load a skill.
+
+## How skill triggering works
+
+At startup agents load only `name` + `description` — just enough to decide when a skill might be relevant. The description carries the entire burden of triggering.
+
+Note: agents typically only consult skills for tasks requiring knowledge beyond what they can handle alone. Simple one-step requests may not trigger a skill even if the description matches.
+
+## Writing effective descriptions
+
+- **Use imperative phrasing:** "Use this skill when..." rather than "This skill does..."
+- **Focus on user intent, not implementation**
+- **Err on the side of being pushy:** list contexts explicitly, including "even if they don't explicitly mention X"
+- **Keep it concise:** a few sentences; hard limit is 1024 characters
+
+## Designing trigger eval queries
+
+Aim for ~20 queries: 8-10 should-trigger, 8-10 should-not-trigger.
+
+```json
+[
+  { "query": "I've got a spreadsheet in ~/data/q4_results.xlsx — can you add a profit margin column?", "should_trigger": true },
+  { "query": "whats the quickest way to convert this json file to yaml", "should_trigger": false }
+]
+```
+
+**Should-trigger queries — vary along:**
+- Phrasing (formal, casual, typos)
+- Explicitness (some name the domain, some describe the need obliquely)
+- Detail (terse vs. context-heavy)
+- Complexity (single-step vs. multi-step)
+
+**Should-not-trigger queries — use near-misses:**
+
+Weak (too easy): `"Write a fibonacci function"`, `"What's the weather today?"`
+
+Strong near-misses for a CSV analysis skill:
+- `"I need to update the formulas in my Excel budget spreadsheet"` — involves spreadsheets but needs Excel editing, not CSV analysis
+- `"write a python script that reads a csv and uploads each row to postgres"` — involves CSV but the task is ETL, not analysis
+
+## Testing whether a description triggers
+
+A query "passes" if:
+- `should_trigger: true` and the skill was invoked, or
+- `should_trigger: false` and the skill was not invoked
+
+Run each query multiple times (3 is a reasonable start). Compute a **trigger rate**: fraction of runs the skill was invoked.
+
+Trigger rate threshold: 0.5 is a reasonable default.
+
+## Avoiding overfitting
+
+Split your query set:
+- **Train set (~60%)**: use to identify failures and guide improvements
+- **Validation set (~40%)**: hold out; only use to check generalisation
+
+## The optimization loop
+
+1. Evaluate on train and validation sets
+2. Identify train set failures (should-trigger misses, should-not-trigger false positives)
+3. Revise the description — generalize, don't add specific keywords from failed queries
+4. Repeat until train set passes or improvement stalls
+5. Select best iteration by validation pass rate
+
+Five iterations is usually enough.
+
+## Applying the result
+
+```yaml
+# Before
+description: Process CSV files.
+
+# After
+description: >
+  Analyze CSV and tabular data files — compute summary statistics,
+  add derived columns, generate charts, and clean messy data. Use this
+  skill when the user has a CSV, TSV, or Excel file and wants to
+  explore, transform, or visualize the data, even if they don't
+  explicitly mention "CSV" or "analysis."
+```
+
+## Next steps
+
+- [Evaluating skill output quality](evaluating-skills.md)
+
+---
+
+*Source: https://agentskills.io/skill-creation/optimizing-descriptions.md — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/skill-creation/quickstart.md
+++ b/docs/vendor/agentskills.io/web/skill-creation/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart
+
+> Create your first Agent Skill and see it work in VS Code.
+
+In this tutorial, you'll create a skill that gives an agent the capability to roll dice using a random number generator.
+
+## Prerequisites
+
+- VS Code with GitHub Copilot
+
+## Create the skill
+
+A skill is a folder containing a `SKILL.md` file. VS Code looks for skills in `.agents/skills/` by default.
+
+Create `.agents/skills/roll-dice/SKILL.md`:
+
+```markdown
+---
+name: roll-dice
+description: Roll dice using a random number generator. Use when asked to roll a die (d6, d20, etc.), roll dice, or generate a random dice roll.
+---
+
+To roll a die, use the following command that generates a random number from 1
+to the given number of sides:
+
+```bash
+echo $((RANDOM % <sides> + 1))
+```
+
+```powershell
+Get-Random -Minimum 1 -Maximum (<sides> + 1)
+```
+
+Replace `<sides>` with the number of sides on the die (e.g., 6 for a standard die, 20 for a d20).
+```
+
+## Try it out
+
+1. Open your project in VS Code
+2. Open the Copilot Chat panel
+3. Select **Agent** mode
+4. Type `/skills` to confirm `roll-dice` appears
+5. Ask: **"Roll a d20"**
+
+## How it works
+
+1. **Discovery** — Agent scans skill directories and reads `name` + `description`
+2. **Activation** — Task matches description; full `SKILL.md` body loads into context
+3. **Execution** — Agent follows the instructions, adapts the command to the request
+
+## Next steps
+
+- [Best practices](best-practices.md)
+- [Optimizing skill descriptions](optimizing-descriptions.md)
+- [Specification](../specification.md)
+- [Example skills](https://github.com/anthropics/skills)
+
+---
+
+*Source: https://agentskills.io/skill-creation/quickstart.md — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/skill-creation/using-scripts.md
+++ b/docs/vendor/agentskills.io/web/skill-creation/using-scripts.md
@@ -1,0 +1,135 @@
+# Using scripts in skills
+
+> How to run commands and bundle executable scripts in your skills.
+
+## One-off commands
+
+When an existing package does what you need, reference it directly in `SKILL.md`:
+
+| Tool | Example | Notes |
+|------|---------|-------|
+| `uvx` | `uvx ruff@0.8.0 check .` | Python; fast caching; requires uv |
+| `pipx` | `pipx run 'black==24.10.0' .` | Python; mature alternative to uvx |
+| `npx` | `npx eslint@9 --fix .` | Node.js; bundled with npm |
+| `bunx` | `bunx eslint@9 --fix .` | Bun environments |
+| `deno run` | `deno run npm:eslint@9 -- --fix .` | Deno; requires permission flags |
+| `go run` | `go run golang.org/x/tools/cmd/goimports@v0.28.0 .` | Go; built-in |
+
+**Tips:**
+- Pin versions for reproducibility
+- State prerequisites in `SKILL.md` or use the `compatibility` frontmatter field
+- Move complex commands into `scripts/` when they're hard to get right inline
+
+## Referencing scripts from `SKILL.md`
+
+Use relative paths from the skill directory root:
+
+```markdown
+## Available scripts
+
+- **`scripts/validate.sh`** — Validates configuration files
+- **`scripts/process.py`** — Processes input data
+
+## Workflow
+
+1. Run validation:
+   ```bash
+   bash scripts/validate.sh "$INPUT_FILE"
+   ```
+
+2. Process results:
+   ```bash
+   python3 scripts/process.py --input results.json
+   ```
+```
+
+## Self-contained scripts
+
+Bundle scripts in `scripts/` with inline dependency declarations:
+
+**Python (PEP 723) — run with `uv run`:**
+
+```python
+# /// script
+# dependencies = [
+#   "beautifulsoup4",
+# ]
+# ///
+
+from bs4 import BeautifulSoup
+...
+```
+
+```bash
+uv run scripts/extract.py
+```
+
+**Deno:**
+
+```typescript
+import * as cheerio from "npm:cheerio@1.0.0";
+```
+
+```bash
+deno run scripts/extract.ts
+```
+
+**Bun:**
+
+```typescript
+import * as cheerio from "cheerio@1.0.0";
+```
+
+```bash
+bun run scripts/extract.ts
+```
+
+## Designing scripts for agentic use
+
+### Avoid interactive prompts (hard requirement)
+
+Agents operate in non-interactive shells — any TTY prompt will hang indefinitely. Accept all input via flags, env vars, or stdin.
+
+```
+# Bad: hangs waiting for input
+$ python scripts/deploy.py
+Target environment: _
+
+# Good: clear error
+$ python scripts/deploy.py
+Error: --env is required. Options: development, staging, production.
+```
+
+### Document usage with `--help`
+
+```
+Usage: scripts/process.py [OPTIONS] INPUT_FILE
+
+Options:
+  --format FORMAT    Output format: json, csv, table (default: json)
+  --output FILE      Write output to FILE instead of stdout
+  --verbose          Print progress to stderr
+```
+
+### Write helpful error messages
+
+```
+Error: --format must be one of: json, csv, table.
+       Received: "xml"
+```
+
+### Use structured output
+
+Prefer JSON, CSV, TSV over free-form text. Send structured data to **stdout**, diagnostics to **stderr**.
+
+### Further considerations
+
+- **Idempotency** — agents may retry; "create if not exists" is safer than "create and fail on duplicate"
+- **Dry-run support** — `--dry-run` flag for destructive operations
+- **Meaningful exit codes** — document different failure types
+- **Safe defaults** — require explicit confirmation flags (`--confirm`, `--force`) for destructive ops
+- **Predictable output size** — default to a summary or limit; support `--offset` for pagination; require `--output FILE` for large outputs
+
+---
+
+*Source: https://agentskills.io/skill-creation/using-scripts.md — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/specification.md
+++ b/docs/vendor/agentskills.io/web/specification.md
@@ -1,0 +1,171 @@
+# Specification
+
+> The complete format specification for Agent Skills.
+
+## Directory structure
+
+A skill is a directory containing, at minimum, a `SKILL.md` file:
+
+```
+skill-name/
+├── SKILL.md          # Required: metadata + instructions
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+├── assets/           # Optional: templates, resources
+└── ...               # Any additional files or directories
+```
+
+## `SKILL.md` format
+
+The `SKILL.md` file must contain YAML frontmatter followed by Markdown content.
+
+### Frontmatter
+
+| Field           | Required | Constraints |
+|-----------------|----------|-------------|
+| `name`          | Yes      | Max 64 characters. Lowercase letters, numbers, and hyphens only. Must not start or end with a hyphen. |
+| `description`   | Yes      | Max 1024 characters. Non-empty. Describes what the skill does and when to use it. |
+| `license`       | No       | License name or reference to a bundled license file. |
+| `compatibility` | No       | Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.). |
+| `metadata`      | No       | Arbitrary key-value mapping for additional metadata. |
+| `allowed-tools` | No       | Space-delimited list of pre-approved tools the skill may use. (Experimental) |
+
+**Minimal example:**
+
+```yaml
+---
+name: skill-name
+description: A description of what this skill does and when to use it.
+---
+```
+
+**Example with optional fields:**
+
+```yaml
+---
+name: pdf-processing
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+license: Apache-2.0
+metadata:
+  author: example-org
+  version: "1.0"
+---
+```
+
+### `name` field
+
+- Must be 1-64 characters
+- May only contain lowercase alphanumeric characters (`a-z`) and hyphens (`-`)
+- Must not start or end with a hyphen (`-`)
+- Must not contain consecutive hyphens (`--`)
+- Must match the parent directory name
+
+Valid: `pdf-processing`, `data-analysis`, `code-review`
+
+Invalid: `PDF-Processing` (uppercase), `-pdf` (starts with hyphen), `pdf--processing` (consecutive hyphens)
+
+### `description` field
+
+- Must be 1-1024 characters
+- Should describe both what the skill does and when to use it
+- Should include specific keywords that help agents identify relevant tasks
+
+Good: `Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs. Use when working with PDF documents or when the user mentions PDFs, forms, or document extraction.`
+
+Poor: `Helps with PDFs.`
+
+### `license` field
+
+- Specifies the license applied to the skill
+- Recommended: keep short (license name or bundled license file reference)
+
+Example: `license: Proprietary. LICENSE.txt has complete terms`
+
+### `compatibility` field
+
+- Must be 1-500 characters if provided
+- Should only be included if the skill has specific environment requirements
+
+Examples:
+```yaml
+compatibility: Designed for Claude Code (or similar products)
+compatibility: Requires git, docker, jq, and access to the internet
+compatibility: Requires Python 3.14+ and uv
+```
+
+### `metadata` field
+
+- A map from string keys to string values
+- Use for additional properties not defined by the spec
+- Use reasonably unique key names to avoid conflicts
+
+```yaml
+metadata:
+  author: example-org
+  version: "1.0"
+```
+
+### `allowed-tools` field
+
+- Space-delimited list of pre-approved tools
+- Experimental — support varies between agent implementations
+
+```yaml
+allowed-tools: Bash(git:*) Bash(jq:*) Read
+```
+
+### Body content
+
+The Markdown body after the frontmatter contains the skill instructions. No format restrictions.
+
+Recommended sections:
+- Step-by-step instructions
+- Examples of inputs and outputs
+- Common edge cases
+
+Keep `SKILL.md` under 500 lines. Move detailed reference material to separate files.
+
+## Optional directories
+
+### `scripts/`
+
+Contains executable code that agents can run. Scripts should be self-contained, include helpful error messages, and handle edge cases gracefully.
+
+### `references/`
+
+Contains additional documentation loaded on demand. Keep files focused — agents load these individually, so smaller files mean less context use.
+
+### `assets/`
+
+Contains static resources: templates, images, data files.
+
+## Progressive disclosure
+
+| Tier | What's loaded | When | Token cost |
+|------|---------------|------|------------|
+| 1. Metadata | `name` + `description` | Session start | ~100 tokens per skill |
+| 2. Instructions | Full `SKILL.md` body | Skill activated | <5000 tokens recommended |
+| 3. Resources | Scripts, references, assets | Referenced by instructions | Varies |
+
+## File references
+
+Use relative paths from the skill root:
+
+```markdown
+See [the reference guide](references/REFERENCE.md) for details.
+
+Run the extraction script:
+scripts/extract.py
+```
+
+## Validation
+
+```bash
+skills-ref validate ./my-skill
+```
+
+Reference library: https://github.com/agentskills/agentskills/tree/main/skills-ref
+
+---
+
+*Source: https://agentskills.io/specification.md — crawled 2026-03-25*

--- a/docs/vendor/agentskills.io/web/what-are-skills.md
+++ b/docs/vendor/agentskills.io/web/what-are-skills.md
@@ -1,0 +1,70 @@
+# What are skills?
+
+> Agent Skills are a lightweight, open format for extending AI agent capabilities with specialized knowledge and workflows.
+
+At its core, a skill is a folder containing a `SKILL.md` file. This file includes metadata (`name` and `description`, at minimum) and instructions that tell an agent how to perform a specific task. Skills can also bundle scripts, templates, and reference materials.
+
+```
+my-skill/
+├── SKILL.md          # Required: instructions + metadata
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+└── assets/           # Optional: templates, resources
+```
+
+## How skills work
+
+Skills use **progressive disclosure** to manage context efficiently:
+
+1. **Discovery**: At startup, agents load only the name and description of each available skill, just enough to know when it might be relevant.
+2. **Activation**: When a task matches a skill's description, the agent reads the full `SKILL.md` instructions into context.
+3. **Execution**: The agent follows the instructions, optionally loading referenced files or executing bundled code as needed.
+
+This approach keeps agents fast while giving them access to more context on demand.
+
+## The SKILL.md file
+
+Every skill starts with a `SKILL.md` file containing YAML frontmatter and Markdown instructions:
+
+```markdown
+---
+name: pdf-processing
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+---
+
+# PDF Processing
+
+## When to use this skill
+Use this skill when the user needs to work with PDF files...
+
+## How to extract text
+1. Use pdfplumber for text extraction...
+
+## How to fill forms
+...
+```
+
+The following frontmatter is required at the top of `SKILL.md`:
+
+- `name`: A short identifier
+- `description`: When to use this skill
+
+The Markdown body contains the actual instructions and has no specific restrictions on structure or content.
+
+This simple format has some key advantages:
+
+- **Self-documenting**: A skill author or user can read a `SKILL.md` and understand what it does, making skills easy to audit and improve.
+- **Extensible**: Skills can range in complexity from just text instructions to executable code, assets, and templates.
+- **Portable**: Skills are just files, so they're easy to edit, version, and share.
+
+## Next steps
+
+- [View the specification](specification.md) to understand the full format.
+- [Add skills support to your agent](client-implementation/adding-skills-support.md) to build a compatible client.
+- [See example skills](https://github.com/anthropics/skills) on GitHub.
+- [Read authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) for writing effective skills.
+- [Use the reference library](https://github.com/agentskills/agentskills/tree/main/skills-ref) to validate skills and generate prompt XML.
+
+---
+
+*Source: https://agentskills.io/what-are-skills.md — crawled 2026-03-25*

--- a/justfile
+++ b/justfile
@@ -1,0 +1,33 @@
+# agentskills — task runner
+# Requires: just (https://github.com/casey/just), uv
+
+_default:
+    @just --list
+
+# Install / update the dev environment
+sync:
+    uv sync
+
+# Lint all skills
+lint:
+    uv run ruff check skills/
+
+# Format all skills
+fmt:
+    uv run ruff format skills/
+
+# Lint + format check (CI-safe, no writes)
+check:
+    uv run ruff check skills/
+    uv run ruff format --check skills/
+
+# Run tests
+test:
+    uv run pytest
+
+# --- uips-log-parser ---
+
+# Run the log parser (pass args after --)
+# Usage: just log-parse -- --last 3 --errors-only
+log-parse *ARGS:
+    uv run skills/uips-log-parser/scripts/parse_logs.py {{ARGS}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "agentskills"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "ruff>=0.8",
+]

--- a/skills/uips-log-parser/SKILL.md
+++ b/skills/uips-log-parser/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: uips-log-parser
+description: >
+  Parse and analyse UiPath Studio local execution logs to diagnose automation
+  runs. Use when a developer asks about errors, warnings, duration, or status of
+  a UiPath process run; when troubleshooting a failed, interrupted, or slow
+  automation; when searching for a specific message across multiple runs. Triggers
+  on: UiPath log, execution log, Studio run, robot error, job failed, process
+  crashed, how long did it run, find in log.
+license: Apache-2.0
+compatibility: Requires Python 3.11+ and uv. Log auto-discovery is Windows-only (UiPath Studio writes logs to %LOCALAPPDATA%\UiPath\Logs\).
+metadata:
+  author: cprima
+  version: "0.1.0"
+allowed-tools: Bash
+---
+
+# UiPath Studio Execution Log Parser
+
+Parse local UiPath Studio execution logs grouped by job run (`jobId`).
+
+## Run the script
+
+```bash
+# Last job (default)
+uv run skills/uips-log-parser/scripts/parse_logs.py
+
+# Specific file
+uv run skills/uips-log-parser/scripts/parse_logs.py --file "C:/Users/<user>/Downloads/2026-03-25_Execution.log"
+
+# Last N runs from auto-discovered logs
+uv run skills/uips-log-parser/scripts/parse_logs.py --last 5
+
+# All runs, errors only
+uv run skills/uips-log-parser/scripts/parse_logs.py --all --errors-only
+
+# Search for a string across all runs
+uv run skills/uips-log-parser/scripts/parse_logs.py --all --needle "Object reference"
+
+# Duration between two copied log lines
+uv run skills/uips-log-parser/scripts/parse_logs.py --duration "LINE1" "LINE2"
+
+# Structured output for further processing
+uv run skills/uips-log-parser/scripts/parse_logs.py --last 3 --format json
+```
+
+All diagnostics go to stderr; `--format json` sends clean JSON to stdout.
+
+## Understanding the output
+
+Each run shows a status flag:
+
+| Flag | Meaning |
+|------|---------|
+| `[ OK ]` | Execution ended normally, no errors |
+| `[FAIL]` | Execution ended normally, with errors |
+| `[ .. ]` | No "execution ended" message — may still be running, was interrupted, or log is truncated |
+
+**Do not assume `[ .. ]` means failure.** The run may be active right now.
+
+## Log auto-discovery
+
+The script searches these locations by default:
+
+- `%LOCALAPPDATA%\UiPath\Logs\` — Studio / attended Robot (user-level)
+- `C:\ProgramData\UiPath\Logs\` — Robot service (system-level)
+
+Use `--log-dir PATH` to override, or `--file PATH` to point at a single file.
+
+## Key CLI flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--last N` | 1 | Show last N runs |
+| `--all` | off | Show all runs |
+| `--days N` | 7 | Discovery lookback window |
+| `--date YYYY-MM-DD` | — | Filter to one day |
+| `--process NAME` | — | Filter by process name (substring) |
+| `--needle TEXT` | — | Filter runs containing TEXT; highlights matches |
+| `--errors-only` | off | Show only runs with errors |
+| `--warnings` | off | Also show warning details |
+| `--format json\|text` | text | Output format |
+| `--list-files` | off | Show discovered files and exit |
+
+## Gotchas
+
+- Log files start with a UTF-8 BOM (`\xEF\xBB\xBF`) — the script strips it automatically.
+- The `[ .. ]` status does **not** indicate a crash when the user is actively developing in Studio.
+- Duration (`totalExecutionTime`) is only present on the final "execution ended" entry. If the run is open, duration will be `null` in JSON / `?` in text.
+- Multiple runs per day are in the same file, separated only by `jobId`.
+- The `execution_log_data/` subfolder contains a SQLite DB (cloud-synced data) — the script does not read it.

--- a/skills/uips-log-parser/scripts/parse_logs.py
+++ b/skills/uips-log-parser/scripts/parse_logs.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""
+UiPath Studio Execution Log Parser
+
+Parses local UiPath execution logs, groups entries by job run (jobId),
+and summarises each run with level counts and error details.
+
+Usage:
+    uv run parse_logs.py
+    uv run parse_logs.py --days 3
+    uv run parse_logs.py --date 2026-03-24
+    uv run parse_logs.py --process BlankProcess --errors-only
+    uv run parse_logs.py --list-files
+    uv run parse_logs.py --format json --all
+
+Convenience utilities (no log files required):
+    uv run parse_logs.py --duration "08:35:14.6902 Info {...}" "08:35:22.9335 Error {...}"
+
+Exit codes:
+    0  success (including "no runs found" with filters)
+    1  input error (file not found, unparseable timestamp)
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Common UiPath execution log locations on Windows (user-level and service-level)
+LOG_LOCATIONS = [
+    Path.home() / "AppData/Local/UiPath/Logs",
+    Path("C:/ProgramData/UiPath/Logs"),
+]
+# Note: %USERPROFILE%\.uipath\ is NOT a known log location and is not searched.
+
+# Each log line: "HH:MM:SS.NNNN Level {...json...}"
+LOG_LINE_RE = re.compile(
+    r"^(?P<time>\d{2}:\d{2}:\d{2}\.\d+)\s+(?P<level_prefix>\w+)\s+(?P<json>\{.+\})$"
+)
+
+LEVEL_ORDER = {
+    "Trace": 0,
+    "Verbose": 1,
+    "Information": 2,
+    "Warning": 3,
+    "Error": 4,
+    "Fatal": 5,
+}
+
+
+def extract_timestamp(log_line: str) -> datetime | None:
+    """
+    Extract a timezone-aware datetime from a raw UiPath log line.
+
+    Tries the JSON 'timeStamp' field first (full ISO-8601 with timezone),
+    falls back to the HH:MM:SS prefix (no date, no tz — same-day only).
+    """
+    m = LOG_LINE_RE.match(log_line.strip().lstrip("\ufeff"))
+    if m:
+        try:
+            data = json.loads(m.group("json"))
+            ts = data.get("timeStamp")
+            if ts:
+                # Python 3.11+ handles colon-less tz offset; fromisoformat is robust enough here
+                return datetime.fromisoformat(ts)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        # Fallback: time prefix only, treat as today, no timezone
+        try:
+            today = datetime.now().strftime("%Y-%m-%d")
+            return datetime.fromisoformat(f"{today}T{m.group('time')}")
+        except ValueError:
+            pass
+    return None
+
+
+def cmd_duration(lines: list[str]) -> None:
+    """Calculate and print the duration between two log lines."""
+    if len(lines) != 2:
+        print("Error: --duration requires exactly 2 log lines.", file=sys.stderr)
+        sys.exit(1)
+
+    t0 = extract_timestamp(lines[0])
+    t1 = extract_timestamp(lines[1])
+
+    if t0 is None:
+        print("Error: could not parse timestamp from first line.", file=sys.stderr)
+        sys.exit(1)
+    if t1 is None:
+        print("Error: could not parse timestamp from second line.", file=sys.stderr)
+        sys.exit(1)
+
+    # Ensure both are comparable (strip tz if only one has it)
+    if t0.tzinfo and t1.tzinfo:
+        delta = abs(t1 - t0)
+    else:
+        delta = abs(t1.replace(tzinfo=None) - t0.replace(tzinfo=None))
+
+    total_seconds = delta.total_seconds()
+    hours, remainder = divmod(int(total_seconds), 3600)
+    minutes, seconds = divmod(remainder, 60)
+    ms = int((total_seconds - int(total_seconds)) * 1000)
+
+    print(f"From : {t0.isoformat()}")
+    print(f"To   : {t1.isoformat()}")
+    if hours:
+        print(f"Delta: {hours}h {minutes}m {seconds}.{ms:03d}s")
+    elif minutes:
+        print(f"Delta: {minutes}m {seconds}.{ms:03d}s")
+    else:
+        print(f"Delta: {seconds}.{ms:03d}s  ({total_seconds:.3f} seconds total)")
+
+
+def find_execution_log_files(days: int = 7, locations: list[Path] | None = None) -> list[Path]:
+    """Discover *_Execution.log files modified within the last N days."""
+    cutoff = datetime.now() - timedelta(days=days)
+    files: list[Path] = []
+    for loc in locations or LOG_LOCATIONS:
+        if not loc.exists():
+            continue
+        for f in sorted(loc.glob("*_Execution.log")):
+            try:
+                file_date = datetime.strptime(f.name[:10], "%Y-%m-%d")
+                if file_date >= cutoff:
+                    files.append(f)
+            except ValueError:
+                continue
+    return sorted(files)
+
+
+def parse_log_file(path: Path) -> list[dict]:
+    """Parse a single execution log file into a list of structured entries."""
+    entries: list[dict] = []
+    try:
+        with open(path, encoding="utf-8-sig") as fh:
+            for lineno, line in enumerate(fh, 1):
+                line = line.rstrip()
+                m = LOG_LINE_RE.match(line)
+                if not m:
+                    continue
+                try:
+                    data = json.loads(m.group("json"))
+                    data["_source_file"] = str(path)
+                    data["_lineno"] = lineno
+                    entries.append(data)
+                except json.JSONDecodeError:
+                    continue
+    except OSError as exc:
+        print(f"  [warn] Cannot read {path}: {exc}", file=sys.stderr)
+    return entries
+
+
+def group_by_job(entries: list[dict]) -> dict[str, list[dict]]:
+    """Group log entries by jobId; entries without a jobId go into 'unknown'."""
+    jobs: dict[str, list[dict]] = defaultdict(list)
+    for entry in entries:
+        jobs[entry.get("jobId", "unknown")].append(entry)
+    return dict(jobs)
+
+
+def summarise_job(job_id: str, entries: list[dict]) -> dict:
+    """Build a summary dict for a single job run."""
+    first = entries[0]
+    last = entries[-1]
+
+    counts: dict[str, int] = defaultdict(int)
+    errors: list[dict] = []
+    warnings: list[dict] = []
+
+    for entry in entries:
+        level = entry.get("level", "Unknown")
+        counts[level] += 1
+        if level in ("Error", "Fatal"):
+            errors.append(entry)
+        elif level == "Warning":
+            warnings.append(entry)
+
+    ended_normally = "execution ended" in last.get("message", "").lower()
+    has_errors = bool(errors)
+
+    if ended_normally and not has_errors:
+        status = "ok"
+    elif ended_normally and has_errors:
+        status = "fail"
+    else:
+        status = "open"  # no end message: still running, interrupted, or log truncated
+
+    return {
+        "jobId": job_id,
+        "processName": first.get("processName", "?"),
+        "processVersion": first.get("processVersion", "?"),
+        "initiatedBy": first.get("initiatedBy", "?"),
+        "robotName": first.get("robotName", "?"),
+        "machineName": first.get("machineName", "?"),
+        "start": first.get("timeStamp", ""),
+        "end": last.get("timeStamp", ""),
+        "duration": last.get("totalExecutionTime"),
+        "durationSec": last.get("totalExecutionTimeInSeconds"),
+        "status": status,
+        "counts": dict(counts),
+        "errors": errors,
+        "warnings": warnings,
+        "_entries": entries,
+    }
+
+
+def _level_badge(counts: dict[str, int]) -> str:
+    """Short counts string, e.g. '12 Info  2 Warn  1 Error'."""
+    parts = []
+    for level in ("Trace", "Verbose", "Information", "Warning", "Error", "Fatal"):
+        n = counts.get(level, 0)
+        if n:
+            parts.append(f"{n} {level[:4]}")
+    return "  ".join(parts) if parts else "—"
+
+
+def print_report(summaries: list[dict], show_warnings: bool = False) -> None:
+    """Print a developer-oriented terminal report."""
+    for s in summaries:
+        flag = {"ok": " OK ", "fail": "FAIL", "open": " .. "}.get(s["status"], " ?? ")
+        start = s["start"][:19].replace("T", " ") if s["start"] else "?"
+        duration = s["duration"] or (
+            f"{s['durationSec']}s" if s["durationSec"] is not None else "?"
+        )
+
+        print(f"\n[{flag}] {start}  {s['processName']} v{s['processVersion']}")
+        print(f"       Job      : {s['jobId']}")
+        print(f"       Initiated: {s['initiatedBy']}  |  Robot: {s['robotName']}")
+        print(f"       Duration : {duration}")
+        print(f"       Levels   : {_level_badge(s['counts'])}")
+
+        if s["errors"]:
+            print(f"       Errors ({len(s['errors'])}):")
+            for e in s["errors"]:
+                ts = e.get("timeStamp", "")[:19].replace("T", " ")
+                msg = e.get("message", "").replace("\r\n", " | ").replace("\n", " | ")
+                print(f"         [{ts}] {e.get('fileName', '?')}: {msg[:300]}")
+
+        if show_warnings and s["warnings"]:
+            print(f"       Warnings ({len(s['warnings'])}):")
+            for w in s["warnings"]:
+                ts = w.get("timeStamp", "")[:19].replace("T", " ")
+                msg = w.get("message", "").replace("\r\n", " | ")
+                print(f"         [{ts}] {msg[:200]}")
+
+        needle = s.get("_needle")
+        if needle:
+            needle_lc = needle.lower()
+            matches = [e for e in s.get("_entries", [])
+                       if needle_lc in e.get("message", "").lower()]
+            print(f"       Needle '{needle}' ({len(matches)} match(es)):")
+            for e in matches:
+                ts = e.get("timeStamp", "")[:19].replace("T", " ")
+                msg = e.get("message", "").replace("\r\n", " | ")
+                print(f"         [{ts}] {e.get('level','?'):11s} {msg[:300]}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Parse UiPath Studio local execution logs, grouped by job run."
+    )
+    parser.add_argument(
+        "--days", type=int, default=7,
+        help="Look back N days for log files (default: 7)"
+    )
+    parser.add_argument(
+        "--date", metavar="YYYY-MM-DD",
+        help="Show only runs from a specific date"
+    )
+    parser.add_argument(
+        "--process", metavar="NAME",
+        help="Filter by process name (case-insensitive substring)"
+    )
+    parser.add_argument(
+        "--duration", nargs=2, metavar=("LINE1", "LINE2"),
+        help="Calculate duration between two raw log lines (no files needed)"
+    )
+    parser.add_argument(
+        "--needle", metavar="TEXT",
+        help="Show only runs containing TEXT in any log message (case-insensitive)"
+    )
+    parser.add_argument(
+        "--errors-only", action="store_true",
+        help="Show only runs that contain errors"
+    )
+    parser.add_argument(
+        "--warnings", action="store_true",
+        help="Also print warning details (not just errors)"
+    )
+    parser.add_argument(
+        "--last", type=int, default=1, metavar="N",
+        help="Show the last N job runs (default: 1, i.e. most recent only)"
+    )
+    parser.add_argument(
+        "--all", dest="show_all", action="store_true",
+        help="Show all job runs (overrides --last)"
+    )
+    parser.add_argument(
+        "--format", choices=["text", "json"], default="text",
+        help="Output format: text (default) or json. JSON sends data to stdout, diagnostics to stderr."
+    )
+    parser.add_argument(
+        "--list-files", action="store_true",
+        help="List discovered log files and exit"
+    )
+    parser.add_argument(
+        "--log-dir", metavar="PATH",
+        help="Override log directory (use instead of auto-discovery)"
+    )
+    parser.add_argument(
+        "--file", metavar="PATH",
+        help="Parse a specific log file directly (skips all discovery and date filters)"
+    )
+    args = parser.parse_args()
+
+    # --- convenience utilities (no log files required) ---
+    if args.duration:
+        cmd_duration(args.duration)
+        return
+
+    if args.file:
+        files = [Path(args.file)]
+        if not files[0].exists():
+            print(f"Error: file not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        locations = [Path(args.log_dir)] if args.log_dir else None
+        files = find_execution_log_files(days=args.days, locations=locations)
+
+        if args.date:
+            files = [f for f in files if f.name.startswith(args.date)]
+
+    if args.list_files:
+        if not files:
+            print("No execution log files found.")
+        for f in files:
+            print(f)
+        return
+
+    if not files:
+        print(
+            f"No execution log files found in the last {args.days} day(s). "
+            "Use --log-dir or --file to specify a path.",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    all_entries: list[dict] = []
+    for f in files:
+        all_entries.extend(parse_log_file(f))
+
+    jobs = group_by_job(all_entries)
+    summaries = [summarise_job(jid, entries) for jid, entries in jobs.items()]
+    summaries.sort(key=lambda s: s["start"])
+
+    if args.process:
+        summaries = [s for s in summaries
+                     if args.process.lower() in s["processName"].lower()]
+
+    if args.needle:
+        needle_lc = args.needle.lower()
+        summaries = [s for s in summaries
+                     if any(needle_lc in e.get("message", "").lower()
+                            for e in s.get("_entries", []))]
+        # attach needle for highlighting in report
+        for s in summaries:
+            s["_needle"] = args.needle
+
+    if args.errors_only:
+        summaries = [s for s in summaries if s["errors"]]
+
+    if not summaries:
+        print("No matching runs found.", file=sys.stderr)
+        sys.exit(0)
+
+    total = len(summaries)
+    if not args.show_all:
+        summaries = summaries[-args.last:]
+
+    shown = len(summaries)
+
+    if args.format == "json":
+        # Strip internal private keys before serialising
+        _PRIVATE = {"_entries", "_needle"}
+        def _clean(s: dict) -> dict:
+            return {k: v for k, v in s.items() if k not in _PRIVATE}
+        print(json.dumps([_clean(s) for s in summaries], indent=2, default=str))
+    else:
+        hint = "" if args.show_all else " (use --last N or --all to see more)"
+        print(
+            f"UiPath Execution Log — showing {shown} of {total} run(s)"
+            f" from {len(files)} file(s){hint}",
+            file=sys.stderr,
+        )
+        print_report(summaries, show_warnings=args.warnings)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,108 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "agentskills"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+]


### PR DESCRIPTION
## Summary

- **`skills/uips-log-parser`** — first skill: parses UiPath Studio local execution logs grouped by `jobId`, with status flags (`ok` / `fail` / `open`), needle search, JSON output, and a `--duration` convenience utility
- **`.claude-plugin/marketplace.json`** — Claude Code skill discovery
- **`pyproject.toml` + `uv.lock` + `justfile`** — single root venv for all skills via `uv`
- **`.github/workflows/strip-docs-from-main.yml`** — strips `docs/` from `main` on merge (closes #2)

## Notes

- `docs/vendor/agentskills.io/web/` is included on `development` for reference during skill authoring; the CI workflow will remove it from `main` automatically after this PR is merged
- `uv.lock` is committed for reproducible installs across environments

## Test plan

- [ ] `uv sync` from repo root creates `.venv` without errors
- [ ] `just log-parse` runs against local UiPath logs
- [ ] After merge, confirm `docs/` is absent from `main` (workflow fires)
- [ ] Skill is discoverable via `.claude-plugin/marketplace.json`

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)